### PR TITLE
uapi: Define __BITS_PER_LONG based on compiler target

### DIFF
--- a/arch/arm64/include/uapi/asm/bitsperlong.h
+++ b/arch/arm64/include/uapi/asm/bitsperlong.h
@@ -16,7 +16,11 @@
 #ifndef __ASM_BITSPERLONG_H
 #define __ASM_BITSPERLONG_H
 
+#ifdef __aarch64__
 #define __BITS_PER_LONG 64
+#else
+#define __BITS_PER_LONG 32
+#endif
 
 #include <asm-generic/bitsperlong.h>
 


### PR DESCRIPTION
This fixes audio and media HAL building.